### PR TITLE
fix: always print in landscape mode

### DIFF
--- a/app/src/components/Chart/ChartContainer.scss
+++ b/app/src/components/Chart/ChartContainer.scss
@@ -288,6 +288,9 @@
 }
 
 @media print {
+  @page {
+    size: landscape;
+  }
   body,
   html {
     display: block;


### PR DESCRIPTION
When exporting a pdf, the default setting for the print is set to _portrait_. This might lead to the impression that the export is broken. By setting the print size to _landscape_ the preview looks as it is intended. 
Before:
<img width="1297" alt="image" src="https://user-images.githubusercontent.com/8025164/206698900-5bc8970f-629f-4778-8bec-39f11a15fd38.png">
Now:
<img width="1247" alt="image" src="https://user-images.githubusercontent.com/8025164/206699078-c85392e2-b44b-42c3-b030-1fa770201bf6.png">
